### PR TITLE
add new line before showing results

### DIFF
--- a/Main.ps1
+++ b/Main.ps1
@@ -17,7 +17,7 @@ if ($interfaceMode -eq 'C') {
 
     # Calculate wages and taxes
     $results = CalculateWagesAndTaxes -inputType $inputType -value $value
-    Write-Host "Results"
+    Write-Host "`nResults"
 
     # Output the results
     Show-Results -results $results


### PR DESCRIPTION
I verified the new line works when running in console mode:

```pwsh
PS /Users/javaswinger/workspaces/EchoEarnings> ./Main.ps1
Enter 'C' for Console Interface or 'G' for GUI Interface: C
Enter 'H' for hourly wage or 'S' for salary: H
Enter your hourly wage: 50

Results
Hourly Wage: $50.00
Bi-Weekly Paycheck (Before Tax): $4,000.00
Bi-Weekly Paycheck (After Tax): $3,328.10 Annual Salary (Before Tax): $104,000.00
Annual Salary (After Tax): $86,530.50
```